### PR TITLE
Thread pool type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,10 @@ impl ThreadPool {
         Self {}
     }
 
-    fn execute<F>(&self, handler: F)
+    fn execute<F, R>(&self, handler: F)
     where
-        F: FnOnce() -> Result<()>,
+        F: FnOnce() -> Result<R>,
+        R: Send,
     {
         if let Err(e) = handler() {
             dbg!(e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,7 @@ impl<R: Send + 'static> ThreadPool<R> {
         let worker = || loop {
             thread::sleep(Duration::from_secs(1));
         };
-        let _workers: Vec<_> = (0..size)
-            .map(|_| thread::spawn(worker))
-            .collect();
+        let _workers: Vec<_> = (0..size).map(|_| thread::spawn(worker)).collect();
 
         Self { _workers }
     }


### PR DESCRIPTION
ThreadPool type definition with the worker thread creation.

It's still not functional, though.  And also, to make the server
up and running while working on the ThreadPool, it reverts
back to the single threaded server.